### PR TITLE
Remove gcc misleading indentation warning

### DIFF
--- a/src/records.c
+++ b/src/records.c
@@ -654,6 +654,6 @@ int remove_record (Record_List *rl, char *alias)
     if (f)
         rl->record_count--;
 
-	rl->total_length -= rec_len;
+    rl->total_length -= rec_len;
     return f ^ 1;
 }


### PR DESCRIPTION
GCC 7.3:
`src/records.c: In function ‘remove_record’:
src/records.c:654:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (f)
     ^~
src/records.c:657:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  rl->total_length -= rec_len;
  ^~
`
